### PR TITLE
Fix deprecated PyTorch and NumPy calls

### DIFF
--- a/craft/data/pseudo_label/make_charbox.py
+++ b/craft/data/pseudo_label/make_charbox.py
@@ -92,7 +92,7 @@ class PseudoCharBoxBuilder:
             )
             word_img_torch = word_img_torch.permute(2, 0, 1).unsqueeze(0)
             word_img_torch = word_img_torch.type(torch.FloatTensor).cuda(gpu)
-            with torch.cuda.amp.autocast():
+            with torch.amp.autocast('cuda'):
                 word_img_scores, _ = net(word_img_torch)
         return word_img_scores
 

--- a/craft/model/craft.py
+++ b/craft/model/craft.py
@@ -60,7 +60,7 @@ class CRAFT(nn.Module):
     def forward(self, x):
         """ Base network """
         if self.amp:
-            with torch.cuda.amp.autocast():
+            with torch.amp.autocast('cuda'):
                 sources = self.basenet(x)
 
                 """ U network """

--- a/craft/train.py
+++ b/craft/train.py
@@ -285,7 +285,7 @@ class Trainer(object):
                     confidence_mask_label = confidence_masks
 
                 if self.config.train.amp:
-                    with torch.cuda.amp.autocast():
+                    with torch.amp.autocast('cuda'):
 
                         output, _ = craft(images)
                         out1 = output[:, :, :, 0]

--- a/craft/utils/inference_boxes.py
+++ b/craft/utils/inference_boxes.py
@@ -234,7 +234,7 @@ def load_icdar2015_gt(dataFolder, isTraing=False):
             word = ",".join(word)
             box_points = np.array(box_points, np.int32).reshape(4, 2)
             cv2.polylines(
-                image, [np.array(box_points).astype(np.int)], True, (0, 0, 255), 1
+                image, [np.array(box_points).astype(int)], True, (0, 0, 255), 1
             )
             box_info_dict["points"] = box_points
             box_info_dict["text"] = word


### PR DESCRIPTION
This commit addresses two main deprecations:

1.  Replaces `torch.cuda.amp.autocast()` with `torch.amp.autocast('cuda')` in the following files:
    - craft/data/pseudo_label/make_charbox.py
    - craft/model/craft.py
    - craft/train.py

2.  Replaces `np.int` with `int` in `craft/utils/inference_boxes.py` to resolve an AttributeError.

These changes ensure compatibility with newer versions of PyTorch and NumPy and resolve the issues you reported.