### PR TITLE
Fix: Update torch.load calls for PyTorch 2.6.0 compatibility

### DIFF
--- a/craft/eval.py
+++ b/craft/eval.py
@@ -248,7 +248,7 @@ def main_eval(model_path, backbone, config, evaluator, result_dir, buffer, model
             raise Exception("Undefined architecture")
 
         print("Loading weights from checkpoint (" + model_path + ")")
-        net_param = torch.load(model_path, map_location=f"cuda:{gpu_idx}")
+        net_param = torch.load(model_path, map_location=f"cuda:{gpu_idx}", weights_only=False)
         model.load_state_dict(copyStateDict(net_param["craft"]))
 
         if config.cuda:

--- a/craft/train.py
+++ b/craft/train.py
@@ -84,7 +84,7 @@ class Trainer(object):
 
         if self.config.train.ckpt_path is not None:
             map_location = "cuda:%d" % gpu
-            param = torch.load(self.config.train.ckpt_path, map_location=map_location)
+            param = torch.load(self.config.train.ckpt_path, map_location=map_location, weights_only=False)
         else:
             param = None
 

--- a/craft/trainSynth.py
+++ b/craft/trainSynth.py
@@ -64,7 +64,7 @@ class Trainer(object):
     def get_load_param(self, gpu):
         if self.config.train.ckpt_path is not None:
             map_location = {"cuda:%d" % 0: "cuda:%d" % gpu}
-            param = torch.load(self.config.train.ckpt_path, map_location=map_location)
+            param = torch.load(self.config.train.ckpt_path, map_location=map_location, weights_only=False)
         else:
             param = None
         return param

--- a/craft/train_distributed.py
+++ b/craft/train_distributed.py
@@ -87,7 +87,7 @@ class Trainer(object):
 
         if self.config.train.ckpt_path is not None:
             map_location = "cuda:%d" % gpu
-            param = torch.load(self.config.train.ckpt_path, map_location=map_location)
+            param = torch.load(self.config.train.ckpt_path, map_location=map_location, weights_only=False)
         else:
             param = None
 


### PR DESCRIPTION
The default behavior of `torch.load` changed in PyTorch 2.6.0. The `weights_only` parameter now defaults to `True`. If a checkpoint contains more than just model weights (e.g., optimizer state, learning rate schedulers, AMP scaler state), `torch.load` would raise an error unless `weights_only` is explicitly set to `False`.

This commit updates all relevant `torch.load` calls in the `craft` codebase to explicitly set `weights_only=False` to maintain the previous behavior and ensure correct loading of full checkpoints.

Files modified:
- craft/eval.py
- craft/train.py
- craft/trainSynth.py
- craft/train_distributed.py